### PR TITLE
Fix enemy chase state invoking

### DIFF
--- a/Ad Astra/Assets/Entities/Enemies/Types/Basic/Scripts/EnemyChaseState_Basic.cs
+++ b/Ad Astra/Assets/Entities/Enemies/Types/Basic/Scripts/EnemyChaseState_Basic.cs
@@ -28,7 +28,8 @@ public class EnemyChaseState_Basic : State
         seeker = input_enemy.gameObject.GetComponent<Seeker>();
         aim = input_enemy.gameObject.GetComponentInChildren<EnemyAim>();
 
-        InvokeRepeating("UpdatePath", 0f, .2f);
+        if (!IsInvoking("UpdatePath"))
+            InvokeRepeating("UpdatePath", 0f, .2f);
     }
     void UpdatePath() {
         seeker.StartPath(transform.position, input_enemy.player.transform.position, OnPathComplete);
@@ -80,6 +81,7 @@ public class EnemyChaseState_Basic : State
     }
     public override void Exit()
     {
+        CancelInvoke("UpdatePath");
 
     }
     private void OnTriggerEnter2D(Collider2D collision)


### PR DESCRIPTION
## Summary
- stop path updates when leaving `EnemyChaseState_Basic`
- avoid stacking multiple `UpdatePath` invokes

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_688292036cd8832f9e8b2abe40545bf9