### PR TITLE
Fix Tetherstorm projectile cleanup

### DIFF
--- a/Ad Astra/Assets/Common/Classes/Projectile.cs
+++ b/Ad Astra/Assets/Common/Classes/Projectile.cs
@@ -19,6 +19,8 @@ public abstract class Projectile : MonoBehaviour
     protected Rigidbody2D _rb;
     public float _timeLeft { get; protected set; }
 
+    protected virtual void Cleanup() { }
+
     private int _ricochets = 0;
     private int _penetrations = 0;
     private float _lastHit = 0;
@@ -70,6 +72,7 @@ public abstract class Projectile : MonoBehaviour
         _timeLeft -= Time.deltaTime;
         if (_timeLeft < 0)
         {
+            Cleanup();
             this.gameObject.SetActive(false);
             Destroy(this.gameObject, 1f);
         }
@@ -150,5 +153,10 @@ public abstract class Projectile : MonoBehaviour
             this.gameObject.SetActive(false);
             Destroy(this.gameObject, 1f);
         }
+    }
+
+    protected virtual void OnDestroy()
+    {
+        Cleanup();
     }
 }

--- a/Ad Astra/Assets/Weapons/Gravity/Tetherstorm/TetherstormProjectile.cs
+++ b/Ad Astra/Assets/Weapons/Gravity/Tetherstorm/TetherstormProjectile.cs
@@ -23,4 +23,10 @@ public class TetherstormProjectile : Projectile
     {
         GeneralFunctions.instance.tetherstormBullets.Remove(_rb);
     }
+
+    protected override void Cleanup()
+    {
+        GeneralFunctions.instance.tetherstormBullets.Remove(_rb);
+        base.Cleanup();
+    }
 }


### PR DESCRIPTION
## Summary
- prevent stale references to destroyed projectiles by adding a cleanup hook
- ensure tetherstorm bullets are removed from `GeneralFunctions.tetherstormBullets`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688292043630832f81a58ef4496041b4