### PR TITLE
Add basic enemy pooling

### DIFF
--- a/Ad Astra/Assets/Common/EnemyPool.cs
+++ b/Ad Astra/Assets/Common/EnemyPool.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyPool : MonoBehaviour
+{
+    public static EnemyPool instance;
+
+    public GameObject enemyPrefab;
+    public int prewarmCount = 10;
+
+    private readonly Queue<GameObject> pool = new Queue<GameObject>();
+
+    private void Awake()
+    {
+        instance = this;
+
+        for (int i = 0; i < prewarmCount; i++)
+        {
+            GameObject enemy = Instantiate(enemyPrefab, transform);
+            enemy.SetActive(false);
+            pool.Enqueue(enemy);
+        }
+    }
+
+    public GameObject Request(Vector3 position)
+    {
+        GameObject enemy = pool.Count > 0 ? pool.Dequeue() : Instantiate(enemyPrefab, transform);
+
+        enemy.transform.position = position;
+        enemy.SetActive(true);
+        return enemy;
+    }
+
+    public void Return(GameObject enemy)
+    {
+        enemy.SetActive(false);
+        pool.Enqueue(enemy);
+    }
+}

--- a/Ad Astra/Assets/Common/EnemyPool.cs.meta
+++ b/Ad Astra/Assets/Common/EnemyPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e42e02a6f19441fa13eae2a0f89626f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Ad Astra/Assets/Common/Game States/GameActiveState.cs
+++ b/Ad Astra/Assets/Common/Game States/GameActiveState.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class GameActiveState : State
 {
     public GameObject spawnTransforms;
-    public GameObject enemyPrefab; // this needs to be changed
+    public EnemyPool enemyPool;
     private float spawnTimer = 0f;
     public float maxSpawnTime = 2f;
 
@@ -35,7 +35,7 @@ public class GameActiveState : State
             int randomSpawnIndex = Random.Range(0, spawnTransforms.transform.childCount);
             Transform randomSpawnTransform = spawnTransforms.transform.GetChild(randomSpawnIndex);
 
-            Instantiate(enemyPrefab, randomSpawnTransform.position, Quaternion.identity);
+            enemyPool.Request(randomSpawnTransform.position);
             GeneralFunctions.instance.enemyCount++;
         }
     }

--- a/Ad Astra/Assets/Entities/Enemies/Scripts/EnemyStateMachine.cs
+++ b/Ad Astra/Assets/Entities/Enemies/Scripts/EnemyStateMachine.cs
@@ -21,9 +21,13 @@ public class EnemyStateMachine : StateMachine
 
         state = idleState;
         player = FindAnyObjectByType<PlayerStateMachine>().gameObject;
+    }
 
+    private void OnEnable()
+    {
         Damageable damageable = GetComponent<Damageable>();
         damageable.Setup(enemyData.maxHealth / GeneralFunctions.instance.globalDifficulty);
+        state = idleState;
     }
     void SelectState()
     {
@@ -53,7 +57,7 @@ public class EnemyStateMachine : StateMachine
         if (newHealth <= 0) {
             GeneralFunctions.instance.RewardXP(enemyData.xp);
             GeneralFunctions.instance.enemyCount--;
-            Destroy(gameObject); // CHANGE
+            EnemyPool.instance.Return(gameObject);
         }
     }
 }

--- a/Ad Astra/Assets/Entities/Enemies/Types/Basic/Scripts/EnemyChaseState_Basic.cs
+++ b/Ad Astra/Assets/Entities/Enemies/Types/Basic/Scripts/EnemyChaseState_Basic.cs
@@ -82,6 +82,10 @@ public class EnemyChaseState_Basic : State
     {
 
     }
+    private void OnDisable()
+    {
+        CancelInvoke("UpdatePath");
+    }
     private void OnTriggerEnter2D(Collider2D collision)
     {
         if (!collision.gameObject.tag.Equals("Player")) return;

--- a/Ad Astra/Assets/Entities/Enemies/Types/Ranged/Scripts/EnemyChaseState_Ranged.cs
+++ b/Ad Astra/Assets/Entities/Enemies/Types/Ranged/Scripts/EnemyChaseState_Ranged.cs
@@ -101,6 +101,11 @@ public class EnemyChaseState_Ranged : State
         CancelInvoke("UpdatePath");
     }
 
+    private void OnDisable()
+    {
+        CancelInvoke("UpdatePath");
+    }
+
     private void OnTriggerEnter2D(Collider2D collision)
     {
         if (!collision.gameObject.tag.Equals("Player")) return;


### PR DESCRIPTION
## Summary
- create `EnemyPool` to reuse enemy GameObjects
- request pooled enemies in `GameActiveState`
- reset enemies on enable and return them to the pool on death
- stop pathfinding invokes when enemies are disabled

## Testing
- `echo "No tests" && true`

------
https://chatgpt.com/codex/tasks/task_e_6882920599ec832f87d7fe665c1aeec1